### PR TITLE
Dispose instances of Nan::Callback in ~StreamingWorker

### DIFF
--- a/streaming/dist/streaming-worker.h
+++ b/streaming/dist/streaming-worker.h
@@ -71,7 +71,10 @@ class StreamingWorker : public AsyncProgressWorker {
     {
       input_closed = false;
     }
-  ~StreamingWorker() {}
+  ~StreamingWorker() {
+    delete progress;
+    delete error_callback;
+  }
 
   void HandleErrorCallback() {
     HandleScope scope;


### PR DESCRIPTION
`StreamingWorkerWrapper` explicitly creates three instances of the `Nan::Callback`: `callback` (which is the only one passed to the `AsyncWorker` constructor in the StreamingWorker initializer), `progress` and `error_callback`. The calling code doesn't manage their lifetime and `StreamingWorker` too. Only `callback` pretends to be disposed in the destructor of the `Nan::AsyncWorker`, but other instances – are not. It looks like a great memory leak: `Nan::Callback` leaks, and `v8::Persistent` owned by `Nan::Callback` leaks too.

This commit adds the explicit disposal of `progress` and `error_calback` instances in the destructor of the `StreamingWorker`, which looks like a great candidate to manage the lifetime of the callbacks.

Btw, i'm curious about the usage of "unmanaged" pointers in the modern C++ code. Why shared pointers are not used in the nan, nor in these examples, nor in the book? :\