### PR TITLE
Provide count to string ctors

### DIFF
--- a/conversions/loose/loose_type_demo.cpp
+++ b/conversions/loose/loose_type_demo.cpp
@@ -43,7 +43,7 @@ void PassString(const FunctionCallbackInfo<Value>& args) {
     Isolate * isolate = args.GetIsolate();
     
     v8::String::Utf8Value s(args[0]);
-    std::string str(*s);
+    std::string str(*s, s.length());
     std::reverse(str.begin(), str.end());    
     
     Local<String> retval = String::NewFromUtf8(isolate, str.c_str());

--- a/conversions/readme.md
+++ b/conversions/readme.md
@@ -126,7 +126,7 @@ void PassString(const FunctionCallbackInfo<Value>& args) {
     Isolate * isolate = args.GetIsolate();
 
     v8::String::Utf8Value s(args[0]);
-    std::string str(*s);
+    std::string str(*s, s.length());
     std::reverse(str.begin(), str.end());    
 
     Local<String> retval = String::NewFromUtf8(isolate, str.c_str());
@@ -176,7 +176,7 @@ void PassString(const FunctionCallbackInfo<Value>& args) {
     }
 
     v8::String::Utf8Value s(args[0]);
-    std::string str(*s);
+    std::string str(*s, s.length());
     std::reverse(str.begin(), str.end());    
 
     Local<String> retval = String::NewFromUtf8(isolate, str.c_str());

--- a/conversions/strict/strict_type_demo.cpp
+++ b/conversions/strict/strict_type_demo.cpp
@@ -81,7 +81,7 @@ void PassString(const FunctionCallbackInfo<Value>& args) {
     }
 
     v8::String::Utf8Value s(args[0]);
-    std::string str(*s);
+    std::string str(*s, s.length());
     std::reverse(str.begin(), str.end());
 
     Local<String> retval = String::NewFromUtf8(isolate, str.c_str());

--- a/conversions_nan/basic_nan.cpp
+++ b/conversions_nan/basic_nan.cpp
@@ -39,7 +39,7 @@ NAN_METHOD(PassBoolean) {
 NAN_METHOD(PassString) {
     v8::String::Utf8Value val(info[0]->ToString());
     
-    std::string str (*val);
+    std::string str(*val, val.length());
     std::reverse(str.begin(), str.end());
     
     info.GetReturnValue().Set(Nan::New<String>(str.c_str()).ToLocalChecked()); 

--- a/objectwrap/polynomial.cpp
+++ b/objectwrap/polynomial.cpp
@@ -109,7 +109,7 @@ void WrappedPoly::GetCoeff(Local<String> property, const PropertyCallbackInfo<Va
     WrappedPoly *obj = ObjectWrap::Unwrap<WrappedPoly>(info.This());
 
     v8::String::Utf8Value s(property);
-    std::string str(*s);
+    std::string str(*s, s.length());
 
     if (str == "a")
     {
@@ -130,7 +130,7 @@ void WrappedPoly::SetCoeff(Local<String> property, Local<Value> value, const Pro
     WrappedPoly *obj = ObjectWrap::Unwrap<WrappedPoly>(info.This());
 
     v8::String::Utf8Value s(property);
-    std::string str(*s);
+    std::string str(*s, s.length());
 
     if (str == "a")
     {

--- a/objectwrap_nan/polynomial.cpp
+++ b/objectwrap_nan/polynomial.cpp
@@ -69,7 +69,7 @@ NAN_GETTER(WrappedPoly::GetCoeff) {
     v8::Isolate* isolate = info.GetIsolate();
     WrappedPoly* obj = ObjectWrap::Unwrap<WrappedPoly>(info.This());
     v8::String::Utf8Value s(property);
-    std::string str(*s);
+    std::string str(*s, s.length());
     if ( str == "a")     info.GetReturnValue().Set(v8::Number::New(isolate, obj->a_));
     else if (str == "b") info.GetReturnValue().Set(v8::Number::New(isolate, obj->b_));
     else if (str == "c") info.GetReturnValue().Set(v8::Number::New(isolate, obj->c_));
@@ -79,7 +79,7 @@ NAN_SETTER(WrappedPoly::SetCoeff) {
     WrappedPoly* obj = ObjectWrap::Unwrap<WrappedPoly>(info.This());
     
     v8::String::Utf8Value s(property);
-    std::string str(*s);
+    std::string str(*s, s.length());
     
     if ( str == "a") obj->a_ = value->NumberValue();
     else if (str == "b") obj->b_ = value->NumberValue();

--- a/quickstart/addon/addon_source.cc
+++ b/quickstart/addon/addon_source.cc
@@ -45,7 +45,7 @@ NAN_METHOD(PassString) {
     }
     v8::String::Utf8Value val(info[0]->ToString());
     
-    std::string str (*val);
+    std::string str (*val, val.length());
     std::reverse(str.begin(), str.end());
     
     info.GetReturnValue().Set(Nan::New<String>(str.c_str()).ToLocalChecked()); 

--- a/rainfall/README.md
+++ b/rainfall/README.md
@@ -206,7 +206,7 @@ sample unpack_sample(Isolate * isolate, const Handle<Object> sample_obj) {
               sample_obj->Get(String::NewFromUtf8(isolate, "rainfall"));
 
   v8::String::Utf8Value utfValue(date_Value);
-  s.date = std::string(*utfValue);
+  s.date = std::string(*utfValue, utfValue.length());
  
   // Unpack the numeric rainfall amount directly from V8 value
   s.rainfall = rainfall_Value->NumberValue();

--- a/rainfall/cpp/rainfall_node.cc
+++ b/rainfall/cpp/rainfall_node.cc
@@ -205,7 +205,7 @@ sample unpack_sample(Isolate * isolate, const Handle<Object> sample_obj) {
   Handle<Value> rainfall_Value = sample_obj->Get(String::NewFromUtf8(isolate, "rainfall"));
 
   v8::String::Utf8Value utfValue(date_Value);
-  s.date = std::string(*utfValue);
+  s.date = std::string(*utfValue, utfValue.length());
 
   // Unpack the numeric rainfall amount directly from V8 value
   s.rainfall = rainfall_Value->NumberValue();


### PR DESCRIPTION
Handles cases with strings containing \0 bytes, otherwise the `std::string` ctor stops as soon as it it reaches a null byte.